### PR TITLE
Changed the advice for Rukus and Crowfood elite/weak adjustment

### DIFF
--- a/Book 3/README.md
+++ b/Book 3/README.md
@@ -120,7 +120,7 @@ Encounters include scaling for level 8 parties.
 
       ![Rukus Graul PNG](./Statblocks/RukusGraul.png)
   
-    - Level 8 adjustment: apply the Elite template to Rukus
+    - If the party is not Level 8 yet, consider applying the weak template to Rukus.
 
  - **Loot:**
    - +1 striking [corrosive](https://2e.aonprd.com/Equipment.aspx?ID=292) spear [P8]
@@ -132,7 +132,7 @@ Encounters include scaling for level 8 parties.
 
     ![Crowfood Graul PNG](./Statblocks/CrowfoodGraul.png)
   
-    - Level 8 adjustment: apply the Elite template to Crowfood
+    - If the party is not Level 8 yet, consider applying the weak template to Crowfood.
 
   - **Loot:**
     - +1 striking ogre hook [P4]


### PR DESCRIPTION
The feedback we got was that Rukus and Crowfood were too strong. Deleted the advice to make them elite if the PCs are lvl8, and gave the advice to make them weak if the PCs are lvl7 instead, essentially dropping them one level.